### PR TITLE
Helpful hints for init function and price function in Dex.sol

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Now when we `yarn deploy --reset` then our contract should be initialized as soo
    // paste in your front-end address here to get balloons on deploy:
    await balloons.transfer(
      "0xe64bAAA0F6012A0F320a262cFe39289bA6cBd0f2",
-     "" + 1 * 10 ** 18
+     "" * 10 ** 18
     );
 ```
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,17 @@ Now when we `yarn deploy --reset` then our contract should be initialized as soo
 
 - [ ] 🎈 Under the debug tab, does your DEX show 5 ETH and 5 Balloons of liquidity?
 
+
+> 💡 _Hint:_ You don't want to be adding extra 10 Balloons when init is called on deploy in `00_deploy_your_contract.js` file.
+
+```
+   // paste in your front-end address here to get balloons on deploy:
+   await balloons.transfer(
+     "0xe64bAAA0F6012A0F320a262cFe39289bA6cBd0f2",
+     "" + 1 * 10 ** 18
+    );
+```
+
 ---
 
 ### ⛳️ **Checkpoint 3: Price** 🤑
@@ -177,6 +188,52 @@ Now, try to edit your DEX.sol smart contract and bring in a price function!
 </details>
 
 We use the ratio of the input vs output reserve to calculate the price to swap either asset for the other. Let’s deploy this and poke around:
+
+<details markdown='1'><summary>💡 Let's have a more mathmatical view of the price function</summary>
+
+Let xInput = x
+Let xReserve = A
+Let yReserve = B
+
+Let yOutput = $
+
+xFee = x*(997) (This is a 0.3% fee) 
+
+numerator(N) = xFee*(B)
+denominator(D) = 1000*(A) + xFee
+
+  $ =  N/D
+
+Example;
+
+Assuming 5 ETH and 5 BAL reserve
+You decide to swap your 2 ETH for some token
+
+using:
+  Price to determine $
+
+ Data:
+  x = 2 ETH
+  A = 5 ETH
+  B = 5 BAL
+  xFee = 2*997 = 1994
+
+ Formula:
+   N/D = (xFee*(B)) / (1000*(A) + xFee)
+
+We have that:
+  N/D = (1994*5) / (5000 + 1994)
+  N/D = 9970/6994
+  N/D = 1.4255076
+
+  Since $ = N/D
+  The ammount of BAL we will recieve will be:
+
+    $ = 1.4255 BAL (Approx.) 
+
+PS: This also applies when swaping BAL to ETH.
+
+</details>
 
 ```
 yarn run deploy

--- a/README.md
+++ b/README.md
@@ -206,8 +206,8 @@ denominator(D) = 1000*(A) + xFee
 
 Example;
 
-Assuming 5 ETH and 5 BAL reserve
-You decide to swap your 2 ETH for some token
+Assuming the DEX has 5 ETH and 5 BAL in it's reserve and
+you decide to swap your 2 ETH for some token.
 
 using:
   Price to determine $
@@ -223,8 +223,8 @@ using:
 
 We have that:
   N/D = (1994*5) / (5000 + 1994)
-  N/D = 9970/6994
-  N/D = 1.4255076
+      = 9970/6994
+      = 1.4255076
 
   Since $ = N/D
   The ammount of BAL we will recieve will be:

--- a/README.md
+++ b/README.md
@@ -191,16 +191,16 @@ We use the ratio of the input vs output reserve to calculate the price to swap e
 
 <details markdown='1'><summary>💡 Let's have a more mathematical view of the price function</summary>
 
-Let xInput = x
-Let xReserve = A
-Let yReserve = B
+Let xInput = x<br>
+Let xReserve = A<br>
+Let yReserve = B<br>
 
 Let yOutput = $
 
-xFee = x*(997) (This is a 0.3% fee) 
+xFee = x*(997) (This is a 0.3% fee) <br>
 
-numerator(N) = xFee*(B)
-denominator(D) = 1000*(A) + xFee
+numerator(N) = xFee*(B) <br>
+denominator(D) = 1000*(A) + xFee <br>
 
   $ =  N/D
 
@@ -209,25 +209,25 @@ Example;
 Assuming the DEX has 5 ETH and 5 BAL in it's reserve and
 you decide to swap your 2 ETH for some token.
 
-using:
-  Price to determine $
+using:<br>
+  Price to determine $<br>
 
- Data:
-  x = 2 ETH
-  A = 5 ETH
-  B = 5 BAL
-  xFee = 2*997 = 1994
+ Data:<br>
+  x = 2 ETH<br>
+  A = 5 ETH<br>
+  B = 5 BAL<br>
+  xFee = 2*997 = 1994<br>
 
- Formula:
+ Formula:<br>
    N/D = (xFee*(B)) / (1000*(A) + xFee)
 
-We have that:
-  N/D = (1994*5) / (5000 + 1994)
-      = 9970/6994
-      = 1.4255076
+We have that:<br>
+  N/D = (1994*5) / (5000 + 1994) <br>
+      = 9970/6994<br>
+      = 1.4255076<br>
 
-  Since $ = N/D
-  The ammount of BAL we will recieve will be:
+  Since $ = N/D<br>
+  The ammount of BAL we will recieve will be:<br>
 
     $ = 1.4255 BAL (Approx.) 
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Now, try to edit your DEX.sol smart contract and bring in a price function!
 
 We use the ratio of the input vs output reserve to calculate the price to swap either asset for the other. Let’s deploy this and poke around:
 
-<details markdown='1'><summary>💡 Let's have a more mathmatical view of the price function</summary>
+<details markdown='1'><summary>💡 Let's have a more mathematical view of the price function</summary>
 
 Let xInput = x
 Let xReserve = A

--- a/packages/hardhat/deploy/00_deploy_your_contract.js
+++ b/packages/hardhat/deploy/00_deploy_your_contract.js
@@ -39,7 +39,7 @@ module.exports = async ({ getNamedAccounts, deployments, getChainId }) => {
   // paste in your front-end address here to get 10 balloons on deploy:
   await balloons.transfer(
     "0x08C01CEc8B8c793D768f502b604113074CE212aD",
-    "" + 1 * 10 ** 18
+    "" + 10 * 10 ** 18
   );
 
   // // uncomment to init DEX on deploy:

--- a/packages/hardhat/deploy/00_deploy_your_contract.js
+++ b/packages/hardhat/deploy/00_deploy_your_contract.js
@@ -39,7 +39,7 @@ module.exports = async ({ getNamedAccounts, deployments, getChainId }) => {
   // paste in your front-end address here to get 10 balloons on deploy:
   await balloons.transfer(
     "0x08C01CEc8B8c793D768f502b604113074CE212aD",
-    "" + 10 * 10 ** 18
+    "" + 1 * 10 ** 18
   );
 
   // // uncomment to init DEX on deploy:


### PR DESCRIPTION
This is to provide extra information to help learners figure things out faster.
Added hints about the calculation in balloon.transfer, to get equal value of ETH and BAL on contract deploy.
Added a mathematical approach to the price function.
All in the README.md file